### PR TITLE
Add Authoring Apps developer section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ import { externalLinkIcon } from "./external-link-icon.js";
 // https://astro.build/config
 export default defineConfig({
   site: "https://fileglancer-docs.janelia.org",
-  base: ".",
+  base: "/",
   markdown: {
     rehypePlugins: [
       [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,6 +73,24 @@ export default defineConfig({
           ],
         },
         {
+          label: "Authoring Apps",
+          items: [
+            { label: "Authoring Apps", slug: "authoring/overview" },
+            { label: "The Manifest", slug: "authoring/manifest-reference" },
+            {
+              label: "Parameters & Command Building",
+              slug: "authoring/parameters",
+            },
+            { label: "Execution Environment", slug: "authoring/execution" },
+            { label: "Services", slug: "authoring/services" },
+            {
+              label: "Auto-Detected Projects",
+              slug: "authoring/auto-detection",
+            },
+            { label: "Server Configuration", slug: "authoring/server-config" },
+          ],
+        },
+        {
           label: "Help & Support",
           items: [
             { label: "Tutorials", slug: "support/tutorials" },

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -20,11 +20,11 @@ If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), File
 - Derives the app **name** from the repository as `owner/repo`, and takes the **description** from the schema's top-level `description`.
 - Converts each JSON Schema parameter into a Fileglancer parameter, preserving types, defaults, descriptions, required flags, `enum` options, and `hidden` status.
 - Groups parameters into [sections](/authoring/parameters/#parameter-sections) based on the schema's `definitions`/`$defs`, ordered by the schema's `allOf` list. Section titles and descriptions come from each definition's `title`, `description`, and `help_text`. All sections start expanded.
-- Adds an **Environment tab** with Nextflow-specific options:
+- Surfaces Nextflow-specific options on the launch form's **Environment tab**:
   - **Profiles** (`-profile`) — comma-separated list of Nextflow profiles (e.g. `standard,docker`)
   - **Extra Arguments** — additional Nextflow CLI arguments (e.g. `-resume`, `-with-tower`), appended to the command without shell quoting
 
-Because these tool-level flags live in `env_parameters`, they are emitted *before* the pipeline parameters, so the generated command is well-formed:
+These tool-level flags are emitted *before* the pipeline parameters, so the generated command is well-formed:
 
 ```bash
 nextflow run . -ansi-log false \

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -1,0 +1,74 @@
+---
+title: Auto-Detected Projects
+description: How Fileglancer automatically turns Nextflow pipelines and Pixi projects into apps without a hand-written manifest — and how to override the generated result.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+You don't always have to write a `runnables.yaml` by hand. If a directory doesn't contain one, Fileglancer looks for recognized project formats and generates a manifest automatically. This means many existing Nextflow pipelines and Pixi projects work as Fileglancer apps with no extra files.
+
+<Aside type="tip" title="A hand-written manifest always wins">
+If a directory contains a `runnables.yaml`, it takes priority and auto-detection is skipped for that directory. To customize an auto-detected app — change the command, add resources, or reorganize parameters — drop a `runnables.yaml` next to the project file and it will be used instead.
+</Aside>
+
+## Nextflow Pipelines
+
+If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), Fileglancer generates a manifest from the Nextflow schema. The generated app:
+
+- Sets `requirements` to `["nextflow"]`.
+- Defines a single entry point named **"Run pipeline"** with the command `nextflow run . -ansi-log false`.
+- Derives the app **name** from the repository as `owner/repo`, and takes the **description** from the schema's top-level `description`.
+- Converts each JSON Schema parameter into a Fileglancer parameter, preserving types, defaults, descriptions, required flags, `enum` options, and `hidden` status.
+- Groups parameters into [sections](/authoring/parameters/#parameter-sections) based on the schema's `definitions`/`$defs`, ordered by the schema's `allOf` list. Section titles and descriptions come from each definition's `title`, `description`, and `help_text`. All sections start expanded.
+- Adds an **Environment tab** with Nextflow-specific options:
+  - **Profiles** (`-profile`) — comma-separated list of Nextflow profiles (e.g. `standard,docker`)
+  - **Extra Arguments** — additional Nextflow CLI arguments (e.g. `-resume`, `-with-tower`), appended to the command without shell quoting
+
+Because these tool-level flags live in `env_parameters`, they are emitted *before* the pipeline parameters, so the generated command is well-formed:
+
+```bash
+nextflow run . -ansi-log false \
+  -profile 'standard,docker' \
+  -resume \
+  --input '/data/input'
+```
+
+Most nf-core and Nextflow pipelines that follow the standard schema convention work out of the box — just add the repo URL in Fileglancer.
+
+## Pixi Projects
+
+If a directory contains a `pixi.toml`, or a `pyproject.toml` with a `[tool.pixi.tasks]` table (and no `runnables.yaml`), Fileglancer generates a manifest from the Pixi configuration. **Each Pixi task becomes its own runnable.** The generated app:
+
+- Sets `requirements` to `["pixi"]`.
+- Uses `pixi run <task_name>` as the command for each runnable, with the task name as both the `id` and display name.
+- Takes each runnable's description from the task's `description` field.
+- Converts task arguments (`args`) into parameters: an arg with `choices` becomes an `enum`, an arg with a `default` carries it over, and an arg with neither is marked required.
+- Exposes each task `env` variable as a **hidden** parameter (with a flag of the form `--env:VARNAME`) so the configured value is visible in the UI without cluttering the form.
+- Prepends `export PATH="$HOME/.pixi/bin:$PATH"` as a `pre_run` step so the `pixi` binary is on `$PATH`.
+- Reads the project `name` and `description` from the project metadata.
+- Collects tasks from both the top-level task table and feature-specific task sections.
+
+Tasks are skipped when they are:
+
+- **Hidden** — the task name starts with an underscore (`_`).
+- **Dependency-only** — the task has no `cmd` (it only declares `depends-on`).
+
+### Example
+
+Given this `pixi.toml`:
+
+```toml title="pixi.toml"
+[project]
+name = "demo"
+description = "A small demo project"
+
+[tasks.greet]
+cmd = "python greet.py"
+description = "Print a greeting"
+args = [
+  { arg = "message", default = "Hello" },
+  { arg = "style", choices = ["plain", "fancy"], default = "plain" },
+]
+```
+
+Fileglancer generates an app named "demo" with a single **greet** runnable that runs `pixi run greet`, offering a free-text **message** parameter and a **style** dropdown (`plain` / `fancy`).

--- a/src/content/docs/authoring/execution.mdx
+++ b/src/content/docs/authoring/execution.mdx
@@ -9,7 +9,9 @@ This page covers everything about *how* and *where* your command runs: setting u
 
 ## The Generated Job Script
 
-When a user submits a job, Fileglancer assembles a shell script and submits it to the cluster. Understanding its structure helps you reason about where your `env`, `pre_run`, `conda_env`, and command fit in.
+When a user submits a job, Fileglancer assembles a shell script and submits it to the cluster. Understanding its structure helps you reason about where your `env`, `pre_run`, `conda_env`, and command fit in. 
+
+Here is an example of the generated script:
 
 ```bash
 unset PIXI_PROJECT_MANIFEST
@@ -111,6 +113,17 @@ When `conda_env` is set, the script initializes conda and activates the environm
 eval "$(conda shell.bash hook)"
 conda activate my-analysis-env
 ```
+
+<Aside type="caution" title="Conda environments are user-wide, not job-scoped">
+A Conda environment is **not** contained to the job's working directory. A named environment lives in the user's shared Conda installation (e.g. `~/miniforge3/envs/`), persists between jobs, and is shared by every app and runnable that references the same name. That global, mutable state brings real risks:
+
+- **Name collisions** — two apps that both expect an env called `analysis` will silently fight over one shared environment, and whichever created it first wins.
+- **Version drift** — if anyone updates, adds to, or rebuilds the environment elsewhere, your job's behavior can change without any edit to your manifest.
+- **Non-reproducibility** — the same manifest can succeed on one machine or account and fail on another, because the result depends on the state of the user's conda install rather than on anything you've declared.
+- **Concurrency hazards** — if a `pre_run` creates the environment on first use, two jobs starting at once can race and leave it half-built or corrupted.
+
+Because of this, when possible we recommend using **[Pixi](https://pixi.sh/)** instead of Conda. A Pixi project pins its dependencies in a lockfile committed alongside your code, resolves into a project-local environment, and reproduces the same versions everywhere. Add `pixi` to your `requirements` and use a `pixi run …` command instead of `conda_env`. 
+</Aside>
 
 <Aside type="tip" title="Creating the environment on first run">
 If the conda environment needs to be created before use (e.g. from an `environment.yml`), use `pre_run` to create it idempotently:

--- a/src/content/docs/authoring/execution.mdx
+++ b/src/content/docs/authoring/execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Execution Environment
-description: Control how your app runs — conda environments, Apptainer containers, pre/post-run scripts, environment variables, the generated job script, and using a separate tool repository.
+description: Control how your app runs — conda environments, Apptainer containers, pre/post-run scripts, environment variables, the generated job script, and the job lifecycle.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -197,27 +197,6 @@ container_args: "--nv"
 </Aside>
 
 The SIF cache directory defaults to `~/.fileglancer/apptainer_cache/` and can be overridden per-user in Preferences, or by the administrator (see [Server Configuration](/authoring/server-config/#container-cache-directory)).
-
-## Separate Tool Repo
-
-By default, the job runs inside the cloned repository that contains the manifest. If your tool code lives in a *different* repository, use the top-level `repo_url` field:
-
-```yaml title="runnables.yaml"
-name: My Pipeline
-repo_url: https://github.com/org/pipeline-code
-runnables:
-  - id: run
-    name: Run Pipeline
-    command: nextflow run main.nf
-    parameters: []
-```
-
-When `repo_url` is set:
-
-- The discovery repo (containing `runnables.yaml`) is used only for manifest metadata.
-- The tool repo (`repo_url`) is cloned separately and used as the working directory for the job.
-
-Repos are cloned into a per-user cache on first use and reused across runs; jobs never pull automatically. To get the newest code, use the **Update** action for the app in the UI, which pulls the latest code and re-reads the manifest.
 
 ## Job Lifecycle
 

--- a/src/content/docs/authoring/execution.mdx
+++ b/src/content/docs/authoring/execution.mdx
@@ -1,0 +1,220 @@
+---
+title: Execution Environment
+description: Control how your app runs — conda environments, Apptainer containers, pre/post-run scripts, environment variables, the generated job script, and using a separate tool repository.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page covers everything about *how* and *where* your command runs: setting up environments, the anatomy of the generated job script, and the lifecycle of a job.
+
+## The Generated Job Script
+
+When a user submits a job, Fileglancer assembles a shell script and submits it to the cluster. Understanding its structure helps you reason about where your `env`, `pre_run`, `conda_env`, and command fit in.
+
+```bash
+unset PIXI_PROJECT_MANIFEST
+export FG_WORK_DIR='/home/user/.fileglancer/jobs/42-MyApp-convert'
+cd "$FG_WORK_DIR/repo"
+
+# Conda activation (if conda_env is set)
+eval "$(conda shell.bash hook)"
+conda activate myenv
+
+# Environment variables (from `env`)
+export JAVA_HOME='/opt/java'
+export NXF_SINGULARITY_CACHEDIR='/scratch/singularity'
+
+# Pre-run script (from `pre_run`)
+module load java/21
+
+# Main command (command + parameters)
+nextflow run main.nf \
+  --input '/data/input' \
+  --outdir '/data/output'
+
+# Post-run script (from `post_run`)
+echo "Conversion complete"
+```
+
+A requirement check (see [Requirements](/authoring/manifest-reference/#requirements)) is prepended ahead of all of this, so unmet requirements fail the job before any of your code runs.
+
+## Environment Variables
+
+The `env` field defines default environment variables exported before the main command runs. Each entry is a `KEY: value` pair.
+
+```yaml
+runnables:
+  - id: convert
+    name: Convert to OME-Zarr
+    command: nextflow run main.nf
+    env:
+      JAVA_HOME: /opt/java
+      NXF_SINGULARITY_CACHEDIR: /scratch/singularity
+```
+
+Users can override or extend these in the UI before submitting. Variable names must match `[A-Za-z_][A-Za-z0-9_]*`, and values are shell-quoted with `shlex.quote()` for safety.
+
+### Variables Set by Fileglancer
+
+Fileglancer exports these variables in every job script. They are available to `pre_run`, the main command, and `post_run`:
+
+| Variable | Availability | Description |
+|----------|-------------|-------------|
+| `FG_WORK_DIR` | All jobs | Absolute path to the job's working directory (contains the `repo/` symlink, log files, etc.) |
+| `SERVICE_URL_PATH` | Service-type jobs only | Absolute path where the service should write its URL. Equivalent to `$FG_WORK_DIR/service_url` (see [Services](/authoring/services/)) |
+
+## Pre/Post-Run Scripts
+
+The `pre_run` and `post_run` fields specify shell commands that run before and after the main command. Use them to load modules, set up the environment, or perform cleanup.
+
+```yaml
+runnables:
+  - id: convert
+    name: Convert to OME-Zarr
+    command: nextflow run main.nf
+    pre_run: |
+      module load java/21
+    post_run: |
+      echo "Conversion complete"
+```
+
+Users can override these in the UI. If a user provides their own script, it replaces the manifest default entirely.
+
+## Conda Environments
+
+The `conda_env` field activates a conda environment before running the command. This requires `miniforge` (or any conda distribution providing the `conda` binary) in the runnable's or manifest's [`requirements`](/authoring/manifest-reference/#requirements).
+
+The value can be:
+
+- **An environment name** (e.g. `myenv`): must match `[a-zA-Z0-9_.-]+`
+- **An absolute path** (e.g. `/opt/envs/myenv`): must not contain shell metacharacters
+
+```yaml title="runnables.yaml"
+name: My Analysis Tool
+runnables:
+  - id: analyze
+    name: Run Analysis
+    command: python analyze.py
+    conda_env: my-analysis-env
+    requirements:
+      - miniforge
+    parameters:
+      - flag: --input
+        name: Input
+        type: file
+        required: true
+```
+
+When `conda_env` is set, the script initializes conda and activates the environment before any env vars, `pre_run`, or the main command:
+
+```bash
+eval "$(conda shell.bash hook)"
+conda activate my-analysis-env
+```
+
+<Aside type="tip" title="Creating the environment on first run">
+If the conda environment needs to be created before use (e.g. from an `environment.yml`), use `pre_run` to create it idempotently:
+
+```yaml
+conda_env: my-tool-env
+pre_run: |
+  conda env create -f environment.yml -n my-tool-env --yes 2>/dev/null || true
+```
+</Aside>
+
+## Containers (Apptainer)
+
+The `container` field runs the command inside a container using [Apptainer](https://apptainer.org/) (formerly Singularity). This requires `apptainer` in the runnable's or manifest's [`requirements`](/authoring/manifest-reference/#requirements).
+
+The value is a container image URL, typically from a Docker/OCI registry:
+
+- `ghcr.io/org/image:tag` — GitHub Container Registry
+- `docker://ghcr.io/org/image:tag` — explicit Docker protocol prefix (added automatically if absent)
+
+```yaml title="runnables.yaml"
+name: Lolcow
+runnables:
+  - id: say
+    name: Cow Say
+    command: cowsay
+    container: godlovedc/lolcow
+    requirements:
+      - apptainer
+    parameters:
+      - name: Message
+        type: string
+        description: What the cow should say
+        required: true
+        default: "Hello from Fileglancer!"
+```
+
+When `container` is set, the generated script creates a SIF cache directory, pulls the image to a `.sif` file if not already cached, and runs the command inside the container via `apptainer exec`:
+
+```bash
+# Apptainer container setup
+APPTAINER_CACHE_DIR=$HOME/.fileglancer/apptainer_cache
+mkdir -p "$APPTAINER_CACHE_DIR"
+SIF_PATH="$APPTAINER_CACHE_DIR/godlovedc_lolcow.sif"
+if [ ! -f "$SIF_PATH" ]; then
+  apptainer pull "$SIF_PATH" 'docker://godlovedc/lolcow'
+fi
+apptainer exec --bind /home/user/.fileglancer/jobs/1-lolcow-say "$SIF_PATH" \
+  cowsay \
+  'Hello from Fileglancer!'
+```
+
+**Bind mounts** are auto-detected from `file` and `directory` parameters, and the job's working directory is always bound. Use `bind_paths` to add extra paths:
+
+```yaml
+container: ghcr.io/org/image:tag
+bind_paths:
+  - /shared/reference-data
+  - /scratch
+```
+
+**Extra Apptainer arguments** can be set as defaults with `container_args`, and overridden by the user at launch time through the Environment tab:
+
+```yaml
+container: ghcr.io/org/cuda-tool:latest
+container_args: "--nv"
+```
+
+<Aside type="caution" title="Mutually exclusive">
+`conda_env` and `container` cannot both be set on the same entry point.
+</Aside>
+
+The SIF cache directory defaults to `~/.fileglancer/apptainer_cache/` and can be overridden per-user in Preferences, or by the administrator (see [Server Configuration](/authoring/server-config/#container-cache-directory)).
+
+## Separate Tool Repo
+
+By default, the job runs inside the cloned repository that contains the manifest. If your tool code lives in a *different* repository, use the top-level `repo_url` field:
+
+```yaml title="runnables.yaml"
+name: My Pipeline
+repo_url: https://github.com/org/pipeline-code
+runnables:
+  - id: run
+    name: Run Pipeline
+    command: nextflow run main.nf
+    parameters: []
+```
+
+When `repo_url` is set:
+
+- The discovery repo (containing `runnables.yaml`) is used only for manifest metadata.
+- The tool repo (`repo_url`) is cloned separately and used as the working directory for the job.
+
+Repos are cloned into a per-user cache on first use and reused across runs; jobs never pull automatically. To get the newest code, use the **Update** action for the app in the UI, which pulls the latest code and re-reads the manifest.
+
+## Job Lifecycle
+
+When a user submits a job:
+
+1. The manifest is re-fetched from the cached clone.
+2. The command is built with validated parameters, with a requirement check prepended.
+3. A working directory is created at `~/.fileglancer/jobs/{id}-{app}-{runnable}/`.
+4. The repository is symlinked into the working directory.
+5. The command runs on the cluster, with `stdout.log` and `stderr.log` captured. Requirements are verified at runtime in the job's execution environment; if any are unmet, the job fails early with a descriptive message in stderr.
+6. Job status is monitored and updated in real time (PENDING → RUNNING → DONE/FAILED/KILLED).
+
+Users can view logs, relaunch with the same parameters, or cancel running jobs from the UI.

--- a/src/content/docs/authoring/manifest-reference.mdx
+++ b/src/content/docs/authoring/manifest-reference.mdx
@@ -1,0 +1,140 @@
+---
+title: The Manifest
+description: Full reference for the runnables.yaml manifest — top-level fields, runnable definitions, resource defaults, and tool requirements.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The `runnables.yaml` manifest describes your app. This page documents its structure: the top-level fields, each runnable's fields, resource defaults, and the requirements system. Parameters are large enough to warrant their own page — see [Parameters & Command Building](/authoring/parameters/).
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Display name shown in the Fileglancer UI |
+| `description` | string | no | Short description of the app |
+| `repo_url` | string | no | GitHub URL of a separate repository containing the tool code (see [Separate Tool Repo](/authoring/execution/#separate-tool-repo)) |
+| `requirements` | list of strings | no | Tools that must be available in the job environment (see [Requirements](#requirements)) |
+| `runnables` | list of objects | yes | One or more runnable definitions (see [Runnables](#runnables)) |
+
+## Runnables
+
+Each runnable defines a single command that users can launch. If a manifest has multiple runnables, the user selects which one to run before the launch form opens.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique identifier (used in CLI flags and URLs, should be URL-safe) |
+| `name` | string | yes | Display name shown in the UI |
+| `type` | string | no | `"job"` (default) for batch jobs or `"service"` for long-running services (see [Services](/authoring/services/)) |
+| `description` | string | no | Longer description of what this runnable does |
+| `command` | string | yes | Base shell command to execute (see [Command Building](/authoring/parameters/#command-building)) |
+| `parameters` | list of objects | no | Parameter definitions shown in the Parameters tab (see [Parameters](/authoring/parameters/)) |
+| `env_parameters` | list of objects | no | Parameters shown in the Environment tab, emitted before `parameters` in the command (see [Environment Tab Parameters](/authoring/parameters/#environment-tab-parameters)) |
+| `resources` | object | no | Default cluster resource requests (see [Resources](#resources)) |
+| `env` | object | no | Default environment variables to export (see [Environment Variables](/authoring/execution/#environment-variables)) |
+| `pre_run` | string | no | Shell script to run before the main command (see [Pre/Post-Run Scripts](/authoring/execution/#prepost-run-scripts)) |
+| `post_run` | string | no | Shell script to run after the main command (see [Pre/Post-Run Scripts](/authoring/execution/#prepost-run-scripts)) |
+| `conda_env` | string | no | Conda environment name or absolute path to activate (see [Conda Environments](/authoring/execution/#conda-environments)) |
+| `container` | string | no | Container image URL for Apptainer (see [Containers](/authoring/execution/#containers-apptainer)) |
+| `bind_paths` | list of strings | no | Additional paths to bind-mount into the container (requires `container`) |
+| `container_args` | string | no | Default extra arguments for container exec (e.g. `--nv`), overridable at launch time |
+| `requirements` | list of strings | no | Additional tool requirements specific to this runnable, merged with manifest-level requirements |
+
+A manifest with two runnables:
+
+```yaml title="runnables.yaml"
+name: Image Toolkit
+description: Convert and inspect microscopy images
+
+runnables:
+  - id: convert
+    name: Convert to OME-Zarr
+    command: python convert.py
+    parameters:
+      - flag: --input
+        name: Input
+        type: file
+        required: true
+
+  - id: inspect
+    name: Inspect Metadata
+    command: python inspect.py
+    parameters:
+      - flag: --path
+        name: Path
+        type: directory
+        required: true
+```
+
+## Resources
+
+Default resource requests for the cluster scheduler. Users can override any of these in the UI before submitting.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpus` | integer | Number of CPUs to request |
+| `memory` | string | Memory allocation, e.g. `"16 GB"` |
+| `walltime` | string | Wall clock time limit, e.g. `"04:00"` (hours:minutes) |
+| `queue` | string | Cluster queue/partition name to submit to |
+
+```yaml
+resources:
+  cpus: 4
+  memory: "16 GB"
+  walltime: "24:00"
+```
+
+If a field is omitted, the server's global default is used. The precedence is: **user override** (highest) → **runnable default** → **server default** (lowest).
+
+## Requirements
+
+The `requirements` field lists tools that must be installed in the job execution environment. Requirements can be specified at two levels:
+
+- **Manifest-level** (`requirements` on the top-level manifest): apply to all runnables by default. Use this for tools needed by every entry point.
+- **Entry-point-level** (`requirements` on a runnable): additional requirements specific to that runnable. These are **merged** with manifest-level requirements when submitting a job. If the same tool appears at both levels, the entry-point version spec takes precedence.
+
+```yaml title="runnables.yaml"
+name: My App
+requirements:
+  - "pixi>=0.40"        # needed by all runnables
+runnables:
+  - id: run
+    name: Run with Pixi
+    command: pixi run demo
+    # effective requirements: [pixi>=0.40]
+
+  - id: container-run
+    name: Run in Container
+    command: cowsay
+    container: godlovedc/lolcow
+    requirements:
+      - apptainer          # only needed by this runnable
+    # effective requirements: [pixi>=0.40, apptainer]
+```
+
+Each entry is a tool name with an optional single version constraint:
+
+```yaml
+requirements:
+  - "pixi>=0.40"
+  - npm
+  - "maven>=3.9"
+  - miniforge
+```
+
+**Supported tools:** `pixi`, `npm`, `maven`, `miniforge`, `apptainer`, `nextflow`
+
+**Supported version operators:** `>=`, `<=`, `!=`, `==`, `>`, `<`
+
+<Aside type="caution" title="One comparison per tool">
+Compound, comma-separated, or chained version constraints such as `"pixi>=0.40,<0.60"` or `"pixi>=0.40<0.60"` are **not** supported. Use at most one comparison per tool.
+</Aside>
+
+### How Requirements Are Checked
+
+A requirement check is prepended to the generated job script and runs at submission time, in the job's actual execution environment (after `$PATH`, conda, and env setup). If a requirement is unmet — the tool is missing or its version is too old — the job fails early with a descriptive message in stderr.
+
+- Only requirements relevant to the **selected** entry point are checked. Unmet requirements for other entry points do not block submission.
+- If `requirements` is omitted or empty at both levels, no checks are performed.
+
+The version of each tool is detected with its standard version command (e.g. `pixi --version`, `nextflow -version`, `mvn --version`, `conda --version` for `miniforge`).

--- a/src/content/docs/authoring/manifest-reference.mdx
+++ b/src/content/docs/authoring/manifest-reference.mdx
@@ -13,7 +13,7 @@ The `runnables.yaml` manifest describes your app. This page documents its struct
 |-------|------|----------|-------------|
 | `name` | string | yes | Display name shown in the Fileglancer UI |
 | `description` | string | no | Short description of the app |
-| `repo_url` | string | no | GitHub URL of a separate repository containing the tool code (see [Separate Tool Repo](/authoring/execution/#separate-tool-repo)) |
+| `repo_url` | string | no | GitHub URL of a separate repository containing the tool code (see [Separate Tool Repo](/authoring/overview/#separate-tool-repo)) |
 | `requirements` | list of strings | no | Tools that must be available in the job environment (see [Requirements](#requirements)) |
 | `runnables` | list of objects | yes | One or more runnable definitions (see [Runnables](#runnables)) |
 

--- a/src/content/docs/authoring/manifest-reference.mdx
+++ b/src/content/docs/authoring/manifest-reference.mdx
@@ -29,7 +29,6 @@ Each runnable defines a single command that users can launch. If a manifest has 
 | `description` | string | no | Longer description of what this runnable does |
 | `command` | string | yes | Base shell command to execute (see [Command Building](/authoring/parameters/#command-building)) |
 | `parameters` | list of objects | no | Parameter definitions shown in the Parameters tab (see [Parameters](/authoring/parameters/)) |
-| `env_parameters` | list of objects | no | Parameters shown in the Environment tab, emitted before `parameters` in the command (see [Environment Tab Parameters](/authoring/parameters/#environment-tab-parameters)) |
 | `resources` | object | no | Default cluster resource requests (see [Resources](#resources)) |
 | `env` | object | no | Default environment variables to export (see [Environment Variables](/authoring/execution/#environment-variables)) |
 | `pre_run` | string | no | Shell script to run before the main command (see [Pre/Post-Run Scripts](/authoring/execution/#prepost-run-scripts)) |

--- a/src/content/docs/authoring/overview.mdx
+++ b/src/content/docs/authoring/overview.mdx
@@ -1,0 +1,120 @@
+---
+title: Authoring Apps
+description: A developer's guide to building apps for Fileglancer. Learn how a runnables.yaml manifest turns a command-line tool into a launchable app with a parameter form, resource controls, and job tracking.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import mascot from '@assets/mascot/fg-engineer.png'
+
+<img src={mascot.src} alt="Fileglancer mascot dressed as an engineer" style="width: 150px; float: right; margin: 0 0 1rem 1rem;" />
+
+Fileglancer can discover and run apps from GitHub repositories. An **app** is a command-line tool that Fileglancer can launch as a cluster job, with a generated parameter form, file/directory pickers, resource controls, and live job tracking — all without the user touching a terminal.
+
+This section is for **tool authors**. If you just want to *use* apps that someone else has published, see the [Apps and Jobs](/workflows/apps-and-jobs/) workflow guide instead.
+
+## How Apps Work
+
+An app is defined by a **manifest** — a `runnables.yaml` file checked into a GitHub repository. The manifest describes one or more **runnables** (also called *entry points*): named commands that a user can launch.
+
+When a user adds your repository, Fileglancer:
+
+1. Clones the repo and searches for manifests describing runnables
+2. Renders a parameter form from each runnable's declared parameters
+3. Builds a shell command from the user's input
+4. Submits it to the compute cluster, capturing logs and tracking status
+
+Your job as an author is to write the manifest. Fileglancer handles the UI, validation, command building, and job lifecycle.
+
+## Quick Start
+
+<Aside type="tip" title="Start from the demo app">
+The [Fileglancer Demo App](https://github.com/JaneliaSciComp/fileglancer-demo-app) is a complete, working repository with a batch job, a service, and a container entry point. It's the fastest way to see an example in action.
+</Aside>
+
+To configure your tool as a Fileglancer app:
+
+1. Create a `runnables.yaml` file in your GitHub repository.
+2. Define one or more runnables with their commands and parameters.
+3. In Fileglancer, open the **Apps** page and add your repository URL.
+
+A minimal manifest:
+
+```yaml title="runnables.yaml"
+name: My Tool
+runnables:
+  - id: run
+    name: Run My Tool
+    command: python main.py
+    parameters: []
+```
+
+This registers an app named "My Tool" with a single entry point that runs `python main.py` in your repository's working directory.
+
+A more realistic manifest adds parameters, which become form fields:
+
+```yaml title="runnables.yaml"
+name: Greeter
+description: Prints a greeting a number of times
+
+runnables:
+  - id: greet
+    name: Print Greeting
+    command: python greet.py
+    parameters:
+      - flag: --message
+        name: Message
+        type: string
+        required: true
+        default: "Hello!"
+      - flag: --repeat
+        name: Repeat Count
+        type: integer
+        default: 3
+        min: 1
+```
+
+When launched, the user fills in **Message** and **Repeat Count**, and Fileglancer runs something like:
+
+```bash
+python greet.py --message 'Hello!' --repeat '3'
+```
+
+## Manifest Discovery
+
+When a user adds a GitHub repository, Fileglancer clones it and walks the directory tree looking for manifest files. These are resolved in the following precedence order:
+
+- **`runnables.yaml`** — an explicit Fileglancer manifest that always takes priority.
+- **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline. 
+- **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project. Each task becomes a runnable.
+
+See [Auto-Detected Projects](/authoring/auto-detection/) for how Nextflow and Pixi repositories are converted, and how to override the result.
+
+The following directories are skipped during discovery: `.git`, `node_modules`, `__pycache__`, `.pixi`, `.venv`, `venv`.
+
+### Multi-App Repositories
+
+A single repository can contain multiple apps by placing manifest files in subdirectories:
+
+```
+my-repo/
+├── tool1/
+│   ├── runnables.yaml    # App: "Image Converter"
+│   └── convert.py
+├── tool2/
+│   ├── runnables.yaml    # App: "Data Analyzer"
+│   └── analyze.py
+└── README.md
+```
+
+Each manifest is discovered and registered as a separate app. When a job runs, the working directory is set to the subdirectory containing the manifest, so relative paths in commands resolve correctly.
+
+## Where to Go Next
+
+This guide is organized into focused pages:
+
+- **[The Manifest](/authoring/manifest-reference/)** — the full `runnables.yaml` field reference: top-level fields, runnables, resources, and requirements.
+- **[Parameters & Command Building](/authoring/parameters/)** — parameter types, flags, sections, hidden parameters, and exactly how user input becomes a shell command.
+- **[Execution Environment](/authoring/execution/)** — conda environments, containers, pre/post-run scripts, environment variables, the generated job script, and using a separate tool repo.
+- **[Services](/authoring/services/)** — long-running entry points like notebooks, viewers, and APIs.
+- **[Auto-Detected Projects](/authoring/auto-detection/)** — how Nextflow and Pixi repositories become apps automatically.
+- **[Server Configuration](/authoring/server-config/)** — settings controlled by the server administrator (`extra_paths`, container cache).

--- a/src/content/docs/authoring/overview.mdx
+++ b/src/content/docs/authoring/overview.mdx
@@ -108,13 +108,34 @@ my-repo/
 
 Each manifest is discovered and registered as a separate app. When a job runs, the working directory is set to the subdirectory containing the manifest, so relative paths in commands resolve correctly.
 
+### Separate Tool Repo
+
+By default, the job runs inside the cloned repository that contains the manifest. If your tool code lives in a *different* repository, use the top-level `repo_url` field:
+
+```yaml title="runnables.yaml"
+name: My Pipeline
+repo_url: https://github.com/org/pipeline-code
+runnables:
+  - id: run
+    name: Run Pipeline
+    command: nextflow run main.nf
+    parameters: []
+```
+
+When `repo_url` is set:
+
+- The discovery repo (containing `runnables.yaml`) is used only for manifest metadata.
+- The tool repo (`repo_url`) is cloned separately and used as the working directory for the job.
+
+Repos are cloned into a per-user cache on first use and reused across runs; jobs never pull automatically. To get the newest code, use the **Update** action for the app in the UI, which pulls the latest code and re-reads the manifest.
+
 ## Where to Go Next
 
 This guide is organized into focused pages:
 
 - **[The Manifest](/authoring/manifest-reference/)** — the full `runnables.yaml` field reference: top-level fields, runnables, resources, and requirements.
 - **[Parameters & Command Building](/authoring/parameters/)** — parameter types, flags, sections, hidden parameters, and exactly how user input becomes a shell command.
-- **[Execution Environment](/authoring/execution/)** — conda environments, containers, pre/post-run scripts, environment variables, the generated job script, and using a separate tool repo.
+- **[Execution Environment](/authoring/execution/)** — conda environments, containers, pre/post-run scripts, environment variables, the generated job script, and the job lifecycle.
 - **[Services](/authoring/services/)** — long-running entry points like notebooks, viewers, and APIs.
 - **[Auto-Detected Projects](/authoring/auto-detection/)** — how Nextflow and Pixi repositories become apps automatically.
 - **[Server Configuration](/authoring/server-config/)** — settings controlled by the server administrator (`extra_paths`, container cache).

--- a/src/content/docs/authoring/parameters.mdx
+++ b/src/content/docs/authoring/parameters.mdx
@@ -113,51 +113,13 @@ parameters:
 
 Hidden parameters still participate in command building — if they have a `default`, it is used even when the parameter is not visible. Hidden parameters inside a section are filtered individually; if all parameters in a section are hidden, the entire section is hidden until the toggle is turned on.
 
-## Environment Tab Parameters
-
-The `env_parameters` field works identically to `parameters` (same types, sections, flags) but places the parameters in the **Environment tab** instead of the Parameters tab. This is useful for tool-level options that are separate from the app's own parameters.
-
-Environment tab parameters are emitted **before** regular parameters in the generated command. This matters for tools like Nextflow, where tool-level flags (e.g. `-profile`) must appear before pipeline parameters (e.g. `--input`).
-
-```yaml
-runnables:
-  - id: run
-    name: Run Pipeline
-    command: nextflow run . -ansi-log false
-    env_parameters:
-      - section: Nextflow
-        parameters:
-          - flag: -profile
-            name: Profiles
-            type: string
-            description: Comma-separated list of Nextflow profiles
-          - name: Extra Arguments
-            type: string
-            description: Additional Nextflow CLI arguments
-            raw: true
-    parameters:
-      - flag: --input
-        name: Input
-        type: file
-        required: true
-```
-
-The resulting command:
-
-```bash
-nextflow run . -ansi-log false \
-  -profile 'standard,docker' \
-  -resume -with-tower \
-  --input '/data/input'
-```
-
 ## Command Building
 
 When a job is submitted, Fileglancer constructs the full shell command from the runnable's `command` field and the user-provided values using a two-pass approach:
 
 1. Start with the base `command` string.
 2. Merge user-provided values with defaults for any parameters the user didn't set.
-3. **Pass 1 — Flagged arguments**: emit values for parameters with a `flag`, in declaration order (`env_parameters` first, then `parameters`):
+3. **Pass 1 — Flagged arguments**: emit values for parameters with a `flag`, in declaration order:
    - Boolean `true` → append the flag (e.g. `--verbose`)
    - Boolean `false` → omit entirely
    - All other types → append `{flag} {shell_quoted_value}`

--- a/src/content/docs/authoring/parameters.mdx
+++ b/src/content/docs/authoring/parameters.mdx
@@ -1,0 +1,197 @@
+---
+title: Parameters & Command Building
+description: How to declare parameters, group them into sections, hide advanced options, and understand exactly how user input becomes a safe shell command.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Parameters define the inputs that users fill in through the Fileglancer UI. Each parameter becomes a form field, and its value is appended to your `command` when the job is built. This page covers how to declare parameters and how they are assembled into the final shell command.
+
+## Parameters
+
+Each parameter with a `flag` field becomes a CLI flag appended to the base command. Parameters without a `flag` are emitted as positional arguments.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flag` | string | no | CLI flag syntax (e.g. `--outdir`, `-n`). Omit for positional arguments. Must start with `-` |
+| `name` | string | yes | Display label in the UI |
+| `type` | string | yes | Data type (see [Parameter Types](#parameter-types)) |
+| `description` | string | no | Help text shown below the input field |
+| `required` | boolean | no | Whether the user must provide a value. Default: `false` |
+| `default` | any | no | Pre-filled default value. Type must match the parameter type |
+| `options` | list of strings | no | Allowed values (only for `enum` type) |
+| `min` | number | no | Minimum value (only for `integer` and `number` types) |
+| `max` | number | no | Maximum value (only for `integer` and `number` types) |
+| `pattern` | string | no | Regex validation pattern (only for `string` type, uses full match) |
+| `hidden` | boolean | no | Whether the parameter is hidden by default in the UI. Default: `false` |
+| `raw` | boolean | no | If `true`, the value is appended to the command without shell quoting. Validated against shell metacharacters for safety. Default: `false` |
+
+## Parameter Types
+
+| Type | UI Control | CLI Output (flagged) | CLI Output (positional) | Validation |
+|------|-----------|---------------------|------------------------|------------|
+| `string` | Text input | `--flag 'value'` | `'value'` | Optional `pattern` regex (full match) |
+| `integer` | Number input (step=1) | `--flag 42` | `42` | Must be a whole number. Optional `min`/`max` bounds |
+| `number` | Number input | `--flag 3.14` | `3.14` | Must be numeric. Optional `min`/`max` bounds |
+| `boolean` | Checkbox | `--flag` (if true, omitted if false) | N/A | Must be true/false |
+| `file` | Text input + file browser | `--flag '/path/to/file'` | `'/path/to/file'` | Must be an absolute path that exists and is readable on the server |
+| `directory` | Text input + directory browser | `--flag '/path/to/dir'` | `'/path/to/dir'` | Must be an absolute path that exists and is readable on the server |
+| `enum` | Dropdown select | `--flag 'chosen_value'` | `'chosen_value'` | Value must be one of the `options` list |
+
+**Notes on `file` and `directory` types:**
+
+- The UI provides a browse button alongside the text input, so users can pick paths from the Fileglancer file browser instead of typing them.
+- Paths are validated server-side before job submission (must exist and be accessible).
+- Both absolute paths (`/data/images`) and home-relative paths (`~/output`) are accepted.
+- Shell metacharacters (`;`, `&`, `|`, `` ` ``, `$`, `(`, `)`, etc.) are rejected for safety.
+
+## Flag Forms
+
+Parameters support three flag styles:
+
+- **Double-dash flags** (most common): `flag: --outdir` emits `--outdir '/path'`
+- **Single-dash flags**: `flag: -n` emits `-n 5`
+- **Positional arguments**: omit `flag` entirely. The value is emitted as a bare argument (no flag prefix)
+
+An internal `key` is auto-generated from the flag: `--outdir` becomes key `outdir`, `-n` becomes key `n`. Positional parameters get keys `_arg0`, `_arg1`, etc. Keys must be unique within a runnable.
+
+## Parameter Sections
+
+Parameters can be grouped into collapsible sections in the UI. A section is an item in the `parameters` list that has a `section` key instead of `name`/`type`. Sections contain their own nested `parameters` list (one level deep only). Top-level parameters and sections can be interleaved freely.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `section` | string | yes | Section title displayed in the UI |
+| `description` | string | no | Help text shown next to the section title |
+| `collapsed` | boolean | no | Whether the section starts collapsed. Default: `false` |
+| `parameters` | list of objects | no | Parameter definitions within this section (same schema as top-level parameters) |
+
+```yaml
+parameters:
+  # Top-level parameter (always visible)
+  - flag: --input
+    name: Input Path
+    type: file
+    required: true
+
+  # Collapsible section
+  - section: Advanced Options
+    description: Optional tuning parameters
+    collapsed: true
+    parameters:
+      - flag: --chunk_size
+        name: Chunk Size
+        type: string
+        default: "128,128,128"
+      - flag: --verbose
+        name: Verbose
+        type: boolean
+        default: false
+```
+
+A section with `collapsed: true` renders as a closed accordion; users click to expand it. Sections without `collapsed` (or with `collapsed: false`) start expanded. On form validation, any section containing a parameter with an error is automatically expanded so the user can see and fix the problem.
+
+## Hidden Parameters
+
+Parameters can be marked `hidden: true` to keep them out of the default form view. When any parameter in a runnable is hidden, a **Show hidden** toggle appears in the top right of the Parameters tab; turning it on reveals the hidden parameters.
+
+This is useful for advanced or rarely-changed parameters you want to keep available without cluttering the form.
+
+```yaml
+parameters:
+  - flag: --input
+    name: Input Path
+    type: file
+    required: true
+
+  - flag: --debug-level
+    name: Debug Level
+    type: integer
+    default: 0
+    hidden: true
+```
+
+Hidden parameters still participate in command building — if they have a `default`, it is used even when the parameter is not visible. Hidden parameters inside a section are filtered individually; if all parameters in a section are hidden, the entire section is hidden until the toggle is turned on.
+
+## Environment Tab Parameters
+
+The `env_parameters` field works identically to `parameters` (same types, sections, flags) but places the parameters in the **Environment tab** instead of the Parameters tab. This is useful for tool-level options that are separate from the app's own parameters.
+
+Environment tab parameters are emitted **before** regular parameters in the generated command. This matters for tools like Nextflow, where tool-level flags (e.g. `-profile`) must appear before pipeline parameters (e.g. `--input`).
+
+```yaml
+runnables:
+  - id: run
+    name: Run Pipeline
+    command: nextflow run . -ansi-log false
+    env_parameters:
+      - section: Nextflow
+        parameters:
+          - flag: -profile
+            name: Profiles
+            type: string
+            description: Comma-separated list of Nextflow profiles
+          - name: Extra Arguments
+            type: string
+            description: Additional Nextflow CLI arguments
+            raw: true
+    parameters:
+      - flag: --input
+        name: Input
+        type: file
+        required: true
+```
+
+The resulting command:
+
+```bash
+nextflow run . -ansi-log false \
+  -profile 'standard,docker' \
+  -resume -with-tower \
+  --input '/data/input'
+```
+
+## Command Building
+
+When a job is submitted, Fileglancer constructs the full shell command from the runnable's `command` field and the user-provided values using a two-pass approach:
+
+1. Start with the base `command` string.
+2. Merge user-provided values with defaults for any parameters the user didn't set.
+3. **Pass 1 — Flagged arguments**: emit values for parameters with a `flag`, in declaration order (`env_parameters` first, then `parameters`):
+   - Boolean `true` → append the flag (e.g. `--verbose`)
+   - Boolean `false` → omit entirely
+   - All other types → append `{flag} {shell_quoted_value}`
+4. **Pass 2 — Positional arguments**: emit values for parameters without a `flag`, in declaration order. Values are shell-quoted unless `raw: true` is set, in which case the value is appended as-is (after being validated against shell metacharacters).
+5. Join all parts with line-continuation (`\`) for readability.
+
+For example, given this runnable:
+
+```yaml
+command: pixi run python demo.py
+parameters:
+  - flag: --message
+    name: Message
+    type: string
+    required: true
+  - flag: --repeat
+    name: Repeat Count
+    type: integer
+    default: 3
+  - flag: --verbose
+    name: Verbose
+    type: boolean
+    default: false
+```
+
+If the user provides `message: "Hello"`, `verbose: true`, and leaves `repeat` at its default, the resulting command is:
+
+```bash
+pixi run python demo.py \
+  --message 'Hello' \
+  --verbose \
+  --repeat '3'
+```
+
+<Aside type="caution" title="Shell safety">
+All values are shell-quoted with `shlex.quote()` to prevent injection. The only exception is **positional** parameters with `raw: true`, where the value is appended unquoted but first rejected if it contains shell metacharacters. The `raw` flag has no effect on flagged parameters — those are always quoted.
+</Aside>

--- a/src/content/docs/authoring/server-config.mdx
+++ b/src/content/docs/authoring/server-config.mdx
@@ -1,0 +1,35 @@
+---
+title: Server Configuration
+description: App execution settings controlled by the Fileglancer server administrator — adding tools to $PATH and configuring the container cache directory.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Some aspects of app execution are controlled by the Fileglancer server's `config.yaml`, not by individual app manifests. These settings are managed by the **system administrator** and apply to every job on the server.
+
+<Aside type="note">
+As a tool author you generally don't set these — but knowing they exist explains why a tool like `nextflow` or `pixi` might be available on the cluster without you installing it, and where container images are cached.
+</Aside>
+
+## Extra Paths (`extra_paths`)
+
+The `extra_paths` setting adds directories to `$PATH` for all job scripts. This makes tools like `nextflow`, `pixi`, or `apptainer` available without requiring users to configure their own environments.
+
+```yaml title="config.yaml"
+apps:
+  extra_paths:
+    - /opt/nextflow/bin
+    - /opt/pixi/bin
+    - /usr/local/apptainer/bin
+```
+
+These paths are:
+
+1. **Appended to `$PATH` in every generated job script** — the user's own `$PATH` entries take precedence.
+2. **Visible to the runtime [requirement check](/authoring/manifest-reference/#requirements)** — so `requirements: [nextflow]` can find `/opt/nextflow/bin/nextflow` even if it isn't on the user's default `$PATH`.
+
+## Container Cache Directory
+
+By default, Apptainer container images (SIF files) are cached at `~/.fileglancer/apptainer_cache/`. Users can override this per-user in the Preferences page under "Container cache directory".
+
+See [Containers (Apptainer)](/authoring/execution/#containers-apptainer) for how the cache is used during a job.

--- a/src/content/docs/authoring/services.mdx
+++ b/src/content/docs/authoring/services.mdx
@@ -1,0 +1,94 @@
+---
+title: Services
+description: Author long-running service entry points — notebooks, web viewers, and APIs — that run until the user stops them and expose a URL in the Fileglancer UI.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A **service** is a long-running process — a web server, notebook, API, or viewer — that runs until the user explicitly stops it. Services are declared with `type: service` on the runnable:
+
+```yaml title="runnables.yaml"
+runnables:
+  - id: notebook
+    name: JupyterLab
+    type: service
+    command: jupyter lab --no-browser --ip=0.0.0.0 --port=0
+    resources:
+      cpus: 4
+      memory: "32 GB"
+      walltime: "08:00"
+```
+
+## How It Works
+
+From the cluster's perspective, a service is just a long-running batch job. The difference is in how Fileglancer communicates the service URL to the user:
+
+1. The user launches a service-type runnable → the job enters PENDING.
+2. The cluster picks it up → RUNNING.
+3. The service starts, binds a port, and writes its URL to the file at `SERVICE_URL_PATH`.
+4. On the next poll (every few seconds), Fileglancer reads the file and displays the URL in the UI.
+5. The user clicks **Open Service** → the service opens in a new browser tab.
+6. When done, the user clicks **Stop Service** → the job is killed and the URL disappears.
+
+## Writing the Service URL
+
+For service-type runnables, Fileglancer exports `SERVICE_URL_PATH` — the absolute path to a file where your service should write its URL once it is ready to accept connections.
+
+In Python:
+
+```python
+import os, socket
+
+url = f"http://{socket.gethostname()}:{port}"
+service_url_path = os.environ.get("SERVICE_URL_PATH")
+if service_url_path:
+    with open(service_url_path, "w") as f:
+        f.write(url)
+```
+
+In Bash:
+
+```bash
+echo "http://$(hostname):${PORT}" > "$SERVICE_URL_PATH"
+```
+
+<Aside type="caution" title="URL scheme is validated">
+The URL must start with `http://` or `https://`. Fileglancer validates this before displaying it. If the file doesn't exist or contains an invalid URL, no link is shown.
+</Aside>
+
+## Service Lifecycle
+
+- **Startup**: write the URL to `SERVICE_URL_PATH` as soon as the service is ready. Until the file exists, the UI shows "Service is starting up…".
+- **Running**: Fileglancer reads the URL file on each poll. If the URL changes (e.g. a port rebind), the UI updates automatically.
+- **Shutdown**: when the user clicks **Stop Service**, Fileglancer sends a SIGTERM to the job. Handle this signal for graceful shutdown. Cleaning up the URL file on exit is good practice but not required — Fileglancer only reads it while the job status is RUNNING.
+
+## Tips
+
+- **Port selection**: use port `0` or auto-detection to avoid conflicts when multiple services run on the same node.
+- **Walltime**: set a generous walltime — services run until stopped, but the cluster will kill them when walltime expires. Consider `"08:00"` or longer for interactive sessions.
+- **Flush output**: under a batch scheduler like LSF, Python's stdout may be buffered. Use `flush=True` on print statements or set `PYTHONUNBUFFERED=1` so logs appear in real time.
+
+## Full Service Example
+
+```yaml title="runnables.yaml"
+name: My Viewer
+description: Interactive data viewer
+
+runnables:
+  - id: view
+    name: Start Viewer
+    type: service
+    description: Launch an interactive viewer for browsing datasets
+    command: pixi run python start_viewer.py
+    parameters:
+      - flag: --data-dir
+        name: Data Directory
+        type: directory
+        description: Directory containing datasets to view
+        required: true
+
+    resources:
+      cpus: 2
+      memory: "8 GB"
+      walltime: "08:00"
+```

--- a/src/content/docs/workflows/apps-and-jobs.mdx
+++ b/src/content/docs/workflows/apps-and-jobs.mdx
@@ -77,7 +77,7 @@ When you add a repository, Fileglancer walks the directory tree looking for:
 - **`nextflow_schema.json`** — a Nextflow pipeline schema, automatically converted to an app manifest
 - **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project, where each task becomes a launchable entry point
 
-If you're a tool author, see the [Authoring Apps](https://github.com/JaneliaSciComp/fileglancer/blob/main/docs/AuthoringApps.md) guide for the full manifest reference.
+If you're a tool author, see the [Authoring Apps](/authoring/overview/) guide for the full manifest reference.
 
 ## Launching a Job
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -52,3 +52,13 @@ button[type='button']:hover,
 .sl-markdown-content table :is(td, th) code {
   white-space: nowrap;
 }
+
+/* Highlight the current page in the left sidebar, matching the accent used
+   by the right-hand table of contents */
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='page']:hover,
+.sidebar-content a[aria-current='page']:focus {
+  color: var(--sl-color-text-accent);
+  background-color: var(--sl-color-accent-low);
+  font-weight: 600;
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -47,3 +47,8 @@ button[type='button']:hover,
   height: auto;
   object-fit: contain;
 }
+
+/* Keep inline code (e.g. field names) from breaking mid-word in table cells */
+.sl-markdown-content table :is(td, th) code {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

Adds a new **Authoring Apps** section to the docs for tool authors who write `runnables.yaml` manifests, migrated and expanded from the old `docs/AuthoringApps.md` in the main repo (that file is removed in a companion change).

The guide is factored into focused, cohesive pages rather than one long file:

- **Authoring Apps** (overview) — concepts, quick start, manifest discovery, multi-app repos, and the separate tool repo (`repo_url`)
- **The Manifest** — top-level fields, runnables, resources, requirements
- **Parameters & Command Building** — types, flags, sections, hidden params, two-pass command building
- **Execution Environment** — generated job script, env vars, pre/post-run, conda, containers, job lifecycle
- **Services** — long-running `type: service` entry points
- **Auto-Detected Projects** — Nextflow and Pixi conversion
- **Server Configuration** — admin settings (`extra_paths`, container cache)

## Notable content decisions

- **Corrected stale behavior** vs. the old doc: Nextflow auto-detection derives the app name as `owner/repo` (it does *not* read `nextflow.config`), all generated sections start expanded, and the `queue` resource field is documented.
- **Dropped `env_parameters` from the authoring surface** — it's retained internally for auto-generated manifests but is not something hand-authors should use; all user inputs belong on the Parameters tab.
- Added a caution that **conda environments are user-wide, not job-scoped**, recommending Pixi.

## Site fixes included

- Set `base` to `/` (was `.`), which fixes Starlight's current-page detection so the **left sidebar now highlights the open page**. Production is unaffected — the deploy workflow overrides `base` via `astro build --base`.
- Style the active sidebar link with the same accent the right-hand TOC uses.
- Prevent mid-word line breaks of field names in table cells.

All changes verified with a clean `npm run build` (23 pages).

@StephanPreibisch @JaneliaSciComp/fileglancer 