### PR TITLE
docs: Apps updates — authoring, execution, and workflow docs

### DIFF
--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -5,10 +5,10 @@ description: How Fileglancer automatically turns Nextflow pipelines and Pixi pro
 
 import { Aside } from '@astrojs/starlight/components';
 
-You don't always have to write a `runnables.yaml` by hand. If a repository contains no `runnables.yaml` anywhere, Fileglancer checks the repository **root** for a recognized project format and generates a manifest automatically. This means many existing Nextflow pipelines and Pixi projects work as Fileglancer apps with no extra files.
+You don't always have to write a `runnables.yaml` by hand. If a repository contains no `runnables.yaml` at all, Fileglancer looks for recognized project formats at the repository root and generates a manifest automatically. This means many existing Nextflow pipelines and Pixi projects work as Fileglancer apps with no extra files.
 
 <Aside type="tip" title="A hand-written manifest always wins">
-Hand-written manifests take priority. If Fileglancer finds **any** `runnables.yaml` in the repository, it uses those manifests and skips auto-detection entirely. To customize an auto-detected app — change the command, add resources, or reorganize parameters — add a `runnables.yaml` at the repository root and it will be used instead of the generated manifest.
+Auto-detection runs only when the repository contains **no `runnables.yaml` anywhere**, and it inspects the repository root only. Adding a single `runnables.yaml` — even in a subdirectory — disables auto-detection for the whole repository. To customize an auto-detected app — change the command, add resources, or reorganize parameters — commit a `runnables.yaml` at the repository root and it will be used instead.
 </Aside>
 
 ## Nextflow Pipelines
@@ -43,7 +43,7 @@ If a directory contains a `pixi.toml`, or a `pyproject.toml` with a `[tool.pixi.
 - Uses `pixi run <task_name>` as the command for each runnable, with the task name as both the `id` and display name.
 - Takes each runnable's description from the task's `description` field.
 - Converts task arguments (`args`) into parameters: an arg with `choices` becomes an `enum`, an arg with a `default` carries it over, and an arg with neither is marked required.
-- Maps each task `env` variable to the runnable's `env` defaults, so the configured values are exported in the generated job script (and can be overridden via the launch form's Environment tab).
+- Carries over each task's `env` variables as the runnable's default environment variables. They are exported in the generated job script and appear on the launch form's **Environment** tab, where users can override them.
 - Prepends `export PATH="$HOME/.pixi/bin:$PATH"` as a `pre_run` step so the `pixi` binary is on `$PATH`.
 - Derives the app **name** from the repository as `repo/branch` when added from a Git clone (falling back to the project metadata `name` otherwise), and takes the **description** from the project metadata.
 - Collects tasks from both the top-level task table and feature-specific task sections.

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -11,10 +11,6 @@ You don't always have to write a `runnables.yaml` by hand. If a repository conta
 Hand-written manifests take priority. If Fileglancer finds **any** `runnables.yaml` in the repository, it uses those manifests and skips auto-detection entirely. To customize an auto-detected app — change the command, add resources, or reorganize parameters — add a `runnables.yaml` at the repository root and it will be used instead of the generated manifest.
 </Aside>
 
-<Aside type="note" title="Auto-detection is root-only">
-Auto-detection for Nextflow and Pixi projects only inspects the repository root. A `nextflow_schema.json`, `pixi.toml`, or `pyproject.toml` in a subdirectory is not auto-detected — add a `runnables.yaml` to expose nested projects as apps.
-</Aside>
-
 ## Nextflow Pipelines
 
 If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), Fileglancer generates a manifest from the Nextflow schema. The generated app:
@@ -75,4 +71,4 @@ args = [
 ]
 ```
 
-Fileglancer generates an app with a single **greet** runnable that runs `pixi run greet`, offering a free-text **message** parameter and a **style** dropdown (`plain` / `fancy`). When added from a Git repository the app is named `repo/branch`; the `demo` project name is used only outside a Git clone.
+Fileglancer generates an app with a single **greet** runnable that runs `pixi run greet`, offering a free-text **message** parameter and a **style** dropdown (`plain` / `fancy`). 

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -16,7 +16,7 @@ Hand-written manifests take priority. If Fileglancer finds **any** `runnables.ya
 If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), Fileglancer generates a manifest from the Nextflow schema. The generated app:
 
 - Sets `requirements` to `["nextflow"]`.
-- Defines a single entry point named **"Run pipeline"** with the command `nextflow run . -ansi-log false`.
+- Defines a single entry point named **"Run pipeline"** that launches the pipeline with `nextflow run repo -ansi-log false`, from the job's work directory. Running from the work directory (rather than inside the cloned repo) keeps Nextflow's `.nextflow.log`, `.nextflow/` cache, and `work/` directory in the per-job work directory instead of the shared repo cache. `repo` is a symlink to the clone, and the directory form lets Nextflow resolve the pipeline's main script from its `main.nf` or manifest.
 - Derives the app **name** from the repository as `owner/repo`, and takes the **description** from the schema's top-level `description`.
 - Converts each JSON Schema parameter into a Fileglancer parameter, preserving types, defaults, descriptions, required flags, `enum` options, and `hidden` status.
 - Groups parameters into [sections](/authoring/parameters/#parameter-sections) based on the schema's `definitions`/`$defs`, ordered by the schema's `allOf` list. Section titles and descriptions come from each definition's `title`, `description`, and `help_text`. All sections start expanded.
@@ -27,7 +27,7 @@ If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), File
 These tool-level flags are emitted *before* the pipeline parameters, so the generated command is well-formed:
 
 ```bash
-nextflow run . -ansi-log false \
+cd "$FG_WORK_DIR" && nextflow run repo -ansi-log false \
   -profile 'standard,docker' \
   -resume \
   --input '/data/input'

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -16,7 +16,7 @@ Hand-written manifests take priority. If Fileglancer finds **any** `runnables.ya
 If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), Fileglancer generates a manifest from the Nextflow schema. The generated app:
 
 - Sets `requirements` to `["nextflow"]`.
-- Defines a single entry point named **"Run pipeline"** that launches the pipeline with `nextflow run repo -ansi-log false`, from the job's work directory. Running from the work directory (rather than inside the cloned repo) keeps Nextflow's `.nextflow.log`, `.nextflow/` cache, and `work/` directory in the per-job work directory instead of the shared repo cache. `repo` is a symlink to the clone, and the directory form lets Nextflow resolve the pipeline's main script from its `main.nf` or manifest.
+- Defines a single entry point named **"Run pipeline"** with the command `nextflow run repo -ansi-log false` and [`working_dir: work`](/authoring/execution/#working-directory), so it launches from the job's work directory. Running there (rather than inside the cloned repo) keeps Nextflow's `.nextflow.log`, `.nextflow/` cache, and `work/` directory in the per-job work directory instead of the shared repo cache. `repo` is a symlink to the clone, and the directory form lets Nextflow resolve the pipeline's main script from its `main.nf` or manifest.
 - Derives the app **name** from the repository as `owner/repo`, and takes the **description** from the schema's top-level `description`.
 - Converts each JSON Schema parameter into a Fileglancer parameter, preserving types, defaults, descriptions, required flags, `enum` options, and `hidden` status.
 - Groups parameters into [sections](/authoring/parameters/#parameter-sections) based on the schema's `definitions`/`$defs`, ordered by the schema's `allOf` list. Section titles and descriptions come from each definition's `title`, `description`, and `help_text`. All sections start expanded.
@@ -27,7 +27,7 @@ If a directory contains a `nextflow_schema.json` (and no `runnables.yaml`), File
 These tool-level flags are emitted *before* the pipeline parameters, so the generated command is well-formed:
 
 ```bash
-cd "$FG_WORK_DIR" && nextflow run repo -ansi-log false \
+nextflow run repo -ansi-log false \
   -profile 'standard,docker' \
   -resume \
   --input '/data/input'

--- a/src/content/docs/authoring/auto-detection.mdx
+++ b/src/content/docs/authoring/auto-detection.mdx
@@ -5,10 +5,14 @@ description: How Fileglancer automatically turns Nextflow pipelines and Pixi pro
 
 import { Aside } from '@astrojs/starlight/components';
 
-You don't always have to write a `runnables.yaml` by hand. If a directory doesn't contain one, Fileglancer looks for recognized project formats and generates a manifest automatically. This means many existing Nextflow pipelines and Pixi projects work as Fileglancer apps with no extra files.
+You don't always have to write a `runnables.yaml` by hand. If a repository contains no `runnables.yaml` anywhere, Fileglancer checks the repository **root** for a recognized project format and generates a manifest automatically. This means many existing Nextflow pipelines and Pixi projects work as Fileglancer apps with no extra files.
 
 <Aside type="tip" title="A hand-written manifest always wins">
-If a directory contains a `runnables.yaml`, it takes priority and auto-detection is skipped for that directory. To customize an auto-detected app — change the command, add resources, or reorganize parameters — drop a `runnables.yaml` next to the project file and it will be used instead.
+Hand-written manifests take priority. If Fileglancer finds **any** `runnables.yaml` in the repository, it uses those manifests and skips auto-detection entirely. To customize an auto-detected app — change the command, add resources, or reorganize parameters — add a `runnables.yaml` at the repository root and it will be used instead of the generated manifest.
+</Aside>
+
+<Aside type="note" title="Auto-detection is root-only">
+Auto-detection for Nextflow and Pixi projects only inspects the repository root. A `nextflow_schema.json`, `pixi.toml`, or `pyproject.toml` in a subdirectory is not auto-detected — add a `runnables.yaml` to expose nested projects as apps.
 </Aside>
 
 ## Nextflow Pipelines
@@ -43,9 +47,9 @@ If a directory contains a `pixi.toml`, or a `pyproject.toml` with a `[tool.pixi.
 - Uses `pixi run <task_name>` as the command for each runnable, with the task name as both the `id` and display name.
 - Takes each runnable's description from the task's `description` field.
 - Converts task arguments (`args`) into parameters: an arg with `choices` becomes an `enum`, an arg with a `default` carries it over, and an arg with neither is marked required.
-- Exposes each task `env` variable as a **hidden** parameter (with a flag of the form `--env:VARNAME`) so the configured value is visible in the UI without cluttering the form.
+- Maps each task `env` variable to the runnable's `env` defaults, so the configured values are exported in the generated job script (and can be overridden via the launch form's Environment tab).
 - Prepends `export PATH="$HOME/.pixi/bin:$PATH"` as a `pre_run` step so the `pixi` binary is on `$PATH`.
-- Reads the project `name` and `description` from the project metadata.
+- Derives the app **name** from the repository as `repo/branch` when added from a Git clone (falling back to the project metadata `name` otherwise), and takes the **description** from the project metadata.
 - Collects tasks from both the top-level task table and feature-specific task sections.
 
 Tasks are skipped when they are:
@@ -71,4 +75,4 @@ args = [
 ]
 ```
 
-Fileglancer generates an app named "demo" with a single **greet** runnable that runs `pixi run greet`, offering a free-text **message** parameter and a **style** dropdown (`plain` / `fancy`).
+Fileglancer generates an app with a single **greet** runnable that runs `pixi run greet`, offering a free-text **message** parameter and a **style** dropdown (`plain` / `fancy`). When added from a Git repository the app is named `repo/branch`; the `demo` project name is used only outside a Git clone.

--- a/src/content/docs/authoring/execution.mdx
+++ b/src/content/docs/authoring/execution.mdx
@@ -26,6 +26,10 @@ conda activate myenv
 export JAVA_HOME='/opt/java'
 export NXF_SINGULARITY_CACHEDIR='/scratch/singularity'
 
+# Requirement check (from `requirements`) — verified now that PATH, conda,
+# and env vars are in place
+command -v nextflow >/dev/null 2>&1 || { echo "Missing required tool: nextflow" >&2; exit 1; }
+
 # Pre-run script (from `pre_run`)
 module load java/21
 
@@ -38,7 +42,7 @@ nextflow run main.nf \
 echo "Conversion complete"
 ```
 
-A requirement check (see [Requirements](/authoring/manifest-reference/#requirements)) is prepended ahead of all of this, so unmet requirements fail the job before any of your code runs.
+A requirement check (see [Requirements](/authoring/manifest-reference/#requirements)) runs at job runtime once `$PATH`, conda, and environment variables are set up — but before your `pre_run` script and main command — so unmet requirements fail the job before any of your code runs.
 
 ## Environment Variables
 
@@ -196,7 +200,7 @@ container_args: "--nv"
 `conda_env` and `container` cannot both be set on the same entry point.
 </Aside>
 
-The SIF cache directory defaults to `~/.fileglancer/apptainer_cache/` and can be overridden per-user in Preferences, or by the administrator (see [Server Configuration](/authoring/server-config/#container-cache-directory)).
+The SIF cache directory defaults to `~/.fileglancer/apptainer_cache/` and can be overridden per-user in Preferences (see [Server Configuration](/authoring/server-config/#container-cache-directory)).
 
 ## Job Lifecycle
 

--- a/src/content/docs/authoring/execution.mdx
+++ b/src/content/docs/authoring/execution.mdx
@@ -44,6 +44,23 @@ echo "Conversion complete"
 
 A requirement check (see [Requirements](/authoring/manifest-reference/#requirements)) runs at job runtime once `$PATH`, conda, and environment variables are set up — but before your `pre_run` script and main command — so unmet requirements fail the job before any of your code runs.
 
+## Working Directory
+
+Every job gets a private **work directory** (`$FG_WORK_DIR`), and the cloned project is symlinked into it as `repo`. The `working_dir` runnable field controls which of these the command runs from:
+
+- **`repo`** (default for most runnables) — the script `cd`s into `$FG_WORK_DIR/repo` (or the manifest's subdirectory within it). Use this when the command relies on the project being the current directory — for example Pixi tasks, or scripts that reference sibling files with relative paths.
+- **`work`** (default for **container** runnables) — the script `cd`s into `$FG_WORK_DIR`. The project is still reachable via the `repo` symlink (e.g. `nextflow run repo`). Use this for tools that should write their outputs into a clean per-job directory rather than the shared repo cache.
+
+```yaml
+runnables:
+  - id: run
+    name: Run Pipeline
+    command: nextflow run repo
+    working_dir: work
+```
+
+Containers default to `work` because the repo clone is **not** bind-mounted into the container (only the work directory and your file/directory parameters are), so a container's current directory should be the work dir. A container runnable that genuinely needs the project can set `working_dir: repo` and bind it explicitly.
+
 ## Environment Variables
 
 The `env` field defines default environment variables exported before the main command runs. Each entry is a `KEY: value` pair.

--- a/src/content/docs/authoring/manifest-reference.mdx
+++ b/src/content/docs/authoring/manifest-reference.mdx
@@ -29,6 +29,7 @@ Each runnable defines a single command that users can launch. If a manifest has 
 | `description` | string | no | Longer description of what this runnable does |
 | `command` | string | yes | Base shell command to execute (see [Command Building](/authoring/parameters/#command-building)) |
 | `parameters` | list of objects | no | Parameter definitions shown in the Parameters tab (see [Parameters](/authoring/parameters/)) |
+| `env_parameters` | list of objects | no | Parameter definitions shown in the **Environment** tab instead of the Parameters tab (e.g. a Nextflow `-profile` selector). Same structure as `parameters` (see [Parameters](/authoring/parameters/)) |
 | `resources` | object | no | Default cluster resource requests (see [Resources](#resources)) |
 | `env` | object | no | Default environment variables to export (see [Environment Variables](/authoring/execution/#environment-variables)) |
 | `pre_run` | string | no | Shell script to run before the main command (see [Pre/Post-Run Scripts](/authoring/execution/#prepost-run-scripts)) |
@@ -131,7 +132,7 @@ Compound, comma-separated, or chained version constraints such as `"pixi>=0.40,<
 
 ### How Requirements Are Checked
 
-A requirement check is prepended to the generated job script and runs at submission time, in the job's actual execution environment (after `$PATH`, conda, and env setup). If a requirement is unmet — the tool is missing or its version is too old — the job fails early with a descriptive message in stderr.
+A requirement check is included in the generated job script and runs at **job runtime** on the compute node, in the job's actual execution environment — after the script preamble, `$PATH` additions, conda activation, and environment-variable exports, but before any `pre_run` script and the main command. If a requirement is unmet — the tool is missing or its version is too old — the job fails early with a descriptive message in stderr.
 
 - Only requirements relevant to the **selected** entry point are checked. Unmet requirements for other entry points do not block submission.
 - If `requirements` is omitted or empty at both levels, no checks are performed.

--- a/src/content/docs/authoring/manifest-reference.mdx
+++ b/src/content/docs/authoring/manifest-reference.mdx
@@ -38,6 +38,7 @@ Each runnable defines a single command that users can launch. If a manifest has 
 | `container` | string | no | Container image URL for Apptainer (see [Containers](/authoring/execution/#containers-apptainer)) |
 | `bind_paths` | list of strings | no | Additional paths to bind-mount into the container (requires `container`) |
 | `container_args` | string | no | Default extra arguments for container exec (e.g. `--nv`), overridable at launch time |
+| `working_dir` | string | no | Where the command runs: `repo` (the cloned project, optionally the manifest's subdirectory) or `work` (the job's work directory). Defaults to `work` for container runnables and `repo` otherwise (see [Execution Environment](/authoring/execution/#working-directory)) |
 | `requirements` | list of strings | no | Additional tool requirements specific to this runnable, merged with manifest-level requirements |
 
 A manifest with two runnables:

--- a/src/content/docs/authoring/overview.mdx
+++ b/src/content/docs/authoring/overview.mdx
@@ -81,11 +81,14 @@ python greet.py --message 'Hello!' --repeat '3'
 
 ## Manifest Discovery
 
-When a user adds a GitHub repository, Fileglancer clones it and walks the directory tree looking for manifest files. These are resolved in the following precedence order:
+When a user adds a GitHub repository, Fileglancer clones it and looks for manifest files:
 
-- **`runnables.yaml`** — an explicit Fileglancer manifest that always takes priority.
-- **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline. 
-- **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project. Each task becomes a runnable.
+- **`runnables.yaml`** — an explicit Fileglancer manifest. Fileglancer walks the **entire** directory tree and turns every `runnables.yaml` it finds into an app.
+- If no `runnables.yaml` is found anywhere, Fileglancer falls back to auto-detection at the repository **root only**:
+  - **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline.
+  - **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project. Each task becomes a runnable.
+
+Because auto-detection is root-only and is skipped entirely when any `runnables.yaml` exists, a Nextflow or Pixi project in a subdirectory needs its own `runnables.yaml` to be discovered.
 
 See [Auto-Detected Projects](/authoring/auto-detection/) for how Nextflow and Pixi repositories are converted, and how to override the result.
 

--- a/src/content/docs/authoring/overview.mdx
+++ b/src/content/docs/authoring/overview.mdx
@@ -81,14 +81,12 @@ python greet.py --message 'Hello!' --repeat '3'
 
 ## Manifest Discovery
 
-When a user adds a GitHub repository, Fileglancer clones it and looks for manifest files:
+When a user adds an App from a GitHub repository, Fileglancer clones it and looks for manifest files:
 
 - **`runnables.yaml`** — an explicit Fileglancer manifest. Fileglancer walks the **entire** directory tree and turns every `runnables.yaml` it finds into an app.
 - If no `runnables.yaml` is found anywhere, Fileglancer falls back to auto-detection at the repository **root only**:
   - **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline.
   - **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project. Each task becomes a runnable.
-
-Because auto-detection is root-only and is skipped entirely when any `runnables.yaml` exists, a Nextflow or Pixi project in a subdirectory needs its own `runnables.yaml` to be discovered.
 
 See [Auto-Detected Projects](/authoring/auto-detection/) for how Nextflow and Pixi repositories are converted, and how to override the result.
 

--- a/src/content/docs/authoring/overview.mdx
+++ b/src/content/docs/authoring/overview.mdx
@@ -81,16 +81,16 @@ python greet.py --message 'Hello!' --repeat '3'
 
 ## Manifest Discovery
 
-When a user adds an App from a GitHub repository, Fileglancer clones it and looks for manifest files:
+When a user adds a GitHub repository, Fileglancer clones it and discovers apps in two passes:
 
-- **`runnables.yaml`** — an explicit Fileglancer manifest. Fileglancer walks the **entire** directory tree and turns every `runnables.yaml` it finds into an app.
-- If no `runnables.yaml` is found anywhere, Fileglancer falls back to auto-detection at the repository **root only**:
-  - **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline.
-  - **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project. Each task becomes a runnable.
+1. **Walk the tree for `runnables.yaml`.** Fileglancer scans the entire repository (skipping the directories listed below) and registers a separate app for every `runnables.yaml` it finds. This is the explicit, hand-written manifest format.
+2. **Fall back to auto-detection — only if no `runnables.yaml` exists anywhere.** If the walk turns up no `runnables.yaml` at all, Fileglancer tries its auto-detection adapters against the **repository root**:
+   - **`nextflow_schema.json`** — a Nextflow pipeline. Fileglancer auto-generates a runnable for the pipeline.
+   - **`pixi.toml`** (or `pyproject.toml` with a `[tool.pixi.tasks]` table) — a Pixi project. Each task becomes a runnable.
 
-See [Auto-Detected Projects](/authoring/auto-detection/) for how Nextflow and Pixi repositories are converted, and how to override the result.
+In other words, a single `runnables.yaml` anywhere in the repository disables auto-detection for the whole repository, and auto-detection only ever inspects the repository root (not subdirectories). See [Auto-Detected Projects](/authoring/auto-detection/) for how Nextflow and Pixi repositories are converted, and how to override the result.
 
-The following directories are skipped during discovery: `.git`, `node_modules`, `__pycache__`, `.pixi`, `.venv`, `venv`.
+The following directories are skipped during the walk: `.git`, `node_modules`, `__pycache__`, `.pixi`, `.venv`, `venv`.
 
 ### Multi-App Repositories
 

--- a/src/content/docs/authoring/server-config.mdx
+++ b/src/content/docs/authoring/server-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Server Configuration
-description: App execution settings controlled by the Fileglancer server administrator — adding tools to $PATH and configuring the container cache directory.
+description: App execution settings controlled by the Fileglancer server administrator — adding tools to $PATH — plus where container images are cached.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -30,6 +30,6 @@ These paths are:
 
 ## Container Cache Directory
 
-By default, Apptainer container images (SIF files) are cached at `~/.fileglancer/apptainer_cache/`. Users can override this per-user in the Preferences page under "Container cache directory".
+By default, Apptainer container images (SIF files) are cached at `~/.fileglancer/apptainer_cache/`. There is no server-level setting for this; users override it individually in the Preferences page under "Container cache directory".
 
 See [Containers (Apptainer)](/authoring/execution/#containers-apptainer) for how the cache is used during a job.

--- a/src/content/docs/workflows/apps-and-jobs.mdx
+++ b/src/content/docs/workflows/apps-and-jobs.mdx
@@ -54,19 +54,21 @@ Apps are added by providing a GitHub repository URL. The repository must contain
    Click **Apps** in the navigation bar to open the Apps page.
 
 2. **Click "Add App"**<br/>
-   The Add App dialog opens with fields for the GitHub repository URL and an optional branch name.
+   The Add App dialog opens with a field for the **GitHub Repository URL** and an optional **Revision** field (a tag or branch name).
 
 3. **Enter the repository URL**<br/>
-   Paste the full GitHub URL (e.g. `https://github.com/org/repo`). If the tool lives on a specific branch, enter the branch name as well. Otherwise, the default branch is used.
+   Paste the full GitHub URL (e.g. `https://github.com/org/repo`). To pin the app to a specific tag or branch, fill in the **Revision** field as well. If you leave it blank, Fileglancer uses the repository's default branch.
 
 4. **Click "Add App"**<br/>
    Fileglancer clones the repository and searches for manifest files. If found, the app appears as a card on the Apps page. A single repository can contain multiple apps if it has manifests in different subdirectories.
+
+   The revision is **fixed when the app is added**: the exact tag, branch, or default branch resolved at add time is recorded, so future launches keep using that same version even if the repository's default branch later moves. To track a different revision, re-add the app. See [Updating an App](#updating-an-app) for how to pull newer commits on the pinned revision.
 </Steps>
 
 <StyledImage
   lightSrc={lightAddAppDialog}
   darkSrc={darkAddAppDialog}
-  alt="The 'Add App' dialog with fields for GitHub repository URL and branch name."
+  alt="The 'Add App' dialog with a field for the GitHub repository URL and an optional revision (tag or branch)."
 />
 
 ### What Fileglancer Looks For
@@ -118,17 +120,17 @@ Once an app is added, you can launch it as a job on the compute cluster.
 3. **Fill in parameters on the launch form**<br/>
    The form shows the app's parameters with their types, defaults, and descriptions. For `file` and `directory` parameters, a browse button lets you pick paths from the Fileglancer file browser. Required parameters are marked and validated before submission.
 
-4. **Review resources and environment (optional)**<br/>
-   Switch to the **Cluster** tab and open the Resources section to adjust CPU, memory, and walltime requests. The **Environment** tab lets you set environment variables, pre/post-run scripts, and tool-specific options like Nextflow profiles.
+4. **Review the cluster and environment settings (optional)**<br/>
+   Switch to the **Cluster** tab to adjust CPU, memory, walltime, and queue requests, along with any extra scheduler arguments. The **Environment** tab lets you set environment variables, pre/post-run scripts, and tool-specific options like Nextflow profiles.
 
-5. **Click "Submit"**<br/>
-   The job is submitted to the cluster and you are redirected to the Jobs page. A toast notification confirms the submission.
+5. **Click "Submit Job"**<br/>
+   Click **Submit Job** (or **Start Service** for a service entry point). The job is submitted to the cluster and you are redirected to the Jobs page. A toast notification confirms the submission.
 </Steps>
 
 
 ### Tips for Launching
 
-- **Run the latest version**: If the app's code is actively developed, use **Update** in the app's info dialog before launching to re-fetch the newest manifest and code from the repository.
+- **Running the latest code**: Each launch uses the revision that was pinned when the app was added. If the app's code is actively developed, use the **Update** action in the app's info dialog to pull the newest commits on that revision before launching (see [Updating an App](#updating-an-app)).
 - **Hidden parameters**: Some apps have advanced parameters hidden by default. Toggle "Show hidden" in the Parameters tab to reveal them.
 - **Collapsible sections**: Long parameter forms may group options into collapsible sections. Click a section header to expand or collapse it.
 
@@ -162,6 +164,7 @@ The Jobs page displays a table with the following columns:
 Click an entry point name in the jobs table (or select **View Details** from the actions menu) to open the detail view. This page shows:
 
 - **Header** — app name, entry point, status badge, and timestamps (submitted, started, finished, exit code)
+- **Overview tab** — a summary of the job: its app, entry point, status, and resource requests
 - **Parameters tab** — the parameter values that were used for this job
 - **Script tab** — the generated shell script that was submitted to the cluster, with a link to the script file on disk
 - **Output Log tab** — the job's stdout, streamed in near-real-time while the job is running. Includes a download button
@@ -191,7 +194,7 @@ Each app card has an **info button** (the "i" icon) that opens a dialog with det
 
 ### Updating an App
 
-If the source repository has been updated (e.g. new parameters added, commands changed), you can update the app from the info dialog. This re-fetches the manifest from the repository.
+If the source repository has been updated (e.g. new parameters added, commands changed), you can update the app from the info dialog with the **Update** button. This pulls the newest commits on the app's **pinned revision** and re-reads the manifest. Updating does not change which revision the app tracks — for a branch pin it fetches new commits on that branch, while a tag or commit pin has nothing newer to pull. To move an app to a different revision, re-add it from the new URL.
 
 <StyledImage
   lightSrc={lightAppInfoDialog}
@@ -201,41 +204,32 @@ If the source repository has been updated (e.g. new parameters added, commands c
 
 ### Removing an App
 
-Click the **trash icon** on an app card, or the **Remove** button in the app's info dialog, to remove the app from your library. This does not affect any jobs that have already been submitted — their data and logs remain available on the Jobs page. If you have shared the app to the catalog, removing it from your library does not delete the catalog listing.
+Click the **trash icon** on an app card, or the **Remove** button in the app's info dialog, to remove the app from your library. This does not affect any jobs that have already been submitted — their data and logs remain available on the Jobs page. If you have shared the app to the catalog, removing it from your library does not delete the catalog listing — unshare it first if you want to take it down.
 
-## Using the App Catalog
+## Sharing Apps
 
-The Apps area has two views, selectable from the navigation at the top of the page: **My Apps** (the apps in your personal library) and **App Catalog** (apps that other users have shared). The catalog lets you discover and reuse apps without needing the GitHub URL.
+There are two ways to share an app with colleagues: publishing it to the shared **App Catalog**, or sending someone a direct launch URL.
 
-### Browsing the catalog
+### The App Catalog
 
-Open **App Catalog** to see all shared apps. Each listing shows the app name, description, and who shared it. You can:
+The Apps area has three tabs: **My Apps** (the apps in your library), **App Catalog** (apps shared by anyone on the server), and **Jobs** (your job history).
 
-- **Search** by app name, description, or owner using the search box
-- **Hide installed** apps you already have in your library, using the toggle, so you only see new ones
+To share one of your apps, click the **Share to catalog** icon on its app card (or **Share** from the app's info dialog). You can give the listing a custom **name** and **description** for the catalog — these only affect the catalog entry, not your own copy of the app. Once shared, the app is visible to every Fileglancer user in the **App Catalog** tab.
 
-### Adding an app from the catalog
+To use a shared app, open the **App Catalog** tab, find the app (you can search by name, description, or who shared it, and hide apps you already have), and click **Add to my apps**. This copies the app — pinned to the same revision the publisher shared — into your own library, where it behaves like any other app you added.
 
-Open a listing's info dialog and click **Add to my apps**. The app is added to your library just as if you had entered its GitHub URL, and it then appears under **My Apps** where you can launch it.
+The publisher can edit the listing's name and description at any time, or click **Unshare from catalog** to remove it. Unsharing only removes the catalog listing; it does not affect copies that others have already added to their own libraries.
 
-### Sharing your apps
+### Sharing by URL
 
-To share one of your own apps so others can find it in the catalog, open the app's info dialog and click **Share to Catalog**. Shared apps display a **Shared** badge on their card in My Apps.
-
-To stop sharing, click **Unshare** (from the listing's info dialog or your app card). Unsharing removes the catalog listing but leaves the app in your own library. Likewise, removing a shared app from your library does **not** remove its catalog listing — unshare it first if you want to take it down.
-
-Catalog listings point at the owner's repository and branch. Other users always add the app from that source, so they get whatever the repository currently contains when they add or update it.
-
-## Sharing Apps by URL
-
-Apps can be launched directly via URL without being added to your library first. If someone shares a launch URL with you, Fileglancer will load the app manifest and show the launch form. A banner at the top offers to **Install** the app to your library for quick access later.
+Apps can also be launched directly via URL without being added to your library first. If someone shares a launch URL with you, Fileglancer loads the app manifest and shows the launch form. A banner at the top offers to **Install App** to add it to your library for quick access later.
 
 ## Troubleshooting
 
 **App fails to add**
 - Verify the GitHub URL is correct and the repository is accessible
 - Check that the repository contains a `runnables.yaml`, `nextflow_schema.json`, or `pixi.toml` file
-- If using a specific branch, make sure the branch name is correct
+- If you pinned a specific revision, make sure the tag or branch name is correct
 
 **Job stays in PENDING**
 - The cluster may be busy. Check cluster load or try requesting fewer resources

--- a/src/content/docs/workflows/apps-and-jobs.mdx
+++ b/src/content/docs/workflows/apps-and-jobs.mdx
@@ -108,7 +108,7 @@ Once an app is added, you can launch it as a job on the compute cluster.
 <StyledImage
   lightSrc={lightLaunchForm}
   darkSrc={darkLaunchForm}
-  alt="The app launch form with tabs at the top showing parameters on the left and Resources and Environment to the right. A submit button is at both the top and bottom right."
+  alt="The app launch form with tabs for Parameters, Environment, and Cluster. A submit button is at both the top and bottom right."
 />
 
 <Steps>
@@ -116,7 +116,7 @@ Once an app is added, you can launch it as a job on the compute cluster.
    The form shows the app's parameters with their types, defaults, and descriptions. For `file` and `directory` parameters, a browse button lets you pick paths from the Fileglancer file browser. Required parameters are marked and validated before submission.
 
 4. **Review resources and environment (optional)**<br/>
-   Switch to the **Resources** tab to adjust CPU, memory, and walltime requests. The **Environment** tab lets you set environment variables, pre/post-run scripts, and tool-specific options like Nextflow profiles.
+   Switch to the **Cluster** tab and open the Resources section to adjust CPU, memory, and walltime requests. The **Environment** tab lets you set environment variables, pre/post-run scripts, and tool-specific options like Nextflow profiles.
 
 5. **Click "Submit"**<br/>
    The job is submitted to the cluster and you are redirected to the Jobs page. A toast notification confirms the submission.

--- a/src/content/docs/workflows/apps-and-jobs.mdx
+++ b/src/content/docs/workflows/apps-and-jobs.mdx
@@ -71,9 +71,12 @@ Apps are added by providing a GitHub repository URL. The repository must contain
 
 ### What Fileglancer Looks For
 
-When you add a repository, Fileglancer walks the directory tree looking for:
+When you add a repository, Fileglancer first walks the entire directory tree looking for:
 
-- **`runnables.yaml`** — a manifest file that explicitly defines the app's commands and parameters
+- **`runnables.yaml`** — a manifest file that explicitly defines the app's commands and parameters. Every `runnables.yaml` found anywhere in the repository becomes a separate app.
+
+If no `runnables.yaml` is found anywhere in the repository, Fileglancer falls back to auto-detecting a recognized project format **at the repository root only**:
+
 - **`nextflow_schema.json`** — a Nextflow pipeline schema, automatically converted to an app manifest
 - **`pixi.toml`** (or `pyproject.toml` with `[tool.pixi.tasks]`) — a Pixi project, where each task becomes a launchable entry point
 
@@ -125,7 +128,7 @@ Once an app is added, you can launch it as a job on the compute cluster.
 
 ### Tips for Launching
 
-- **Pull latest**: If the app's code is actively developed, enable "Pull latest" before submitting to ensure you're running the newest version.
+- **Run the latest version**: If the app's code is actively developed, use **Update** in the app's info dialog before launching to re-fetch the newest manifest and code from the repository.
 - **Hidden parameters**: Some apps have advanced parameters hidden by default. Toggle "Show hidden" in the Parameters tab to reveal them.
 - **Collapsible sections**: Long parameter forms may group options into collapsible sections. Click a section header to expand or collapse it.
 
@@ -193,12 +196,35 @@ If the source repository has been updated (e.g. new parameters added, commands c
 <StyledImage
   lightSrc={lightAppInfoDialog}
   darkSrc={darkAppInfoDialog}
-  alt="App info dialog showing the app's description, source repository URL, and a list of entry points. In the bottom left is the 'Launch' button to start a new job with this app, and in the bottom right are 'Update' and 'Delete' buttons, to update or remove the app, respectively."
+  alt="App info dialog showing the app's description, source repository URL, and a list of entry points. In the bottom left is the 'Launch' button to start a new job with this app, and in the bottom right are 'Update' and 'Remove' buttons, to update or remove the app, respectively."
 />
 
 ### Removing an App
 
-Click the **trash icon** on an app card on the 'Delete' button in the app's info dialog to remove the app from your library. This does not affect any jobs that have already been submitted — their data and logs remain available on the Jobs page.
+Click the **trash icon** on an app card, or the **Remove** button in the app's info dialog, to remove the app from your library. This does not affect any jobs that have already been submitted — their data and logs remain available on the Jobs page. If you have shared the app to the catalog, removing it from your library does not delete the catalog listing.
+
+## Using the App Catalog
+
+The Apps area has two views, selectable from the navigation at the top of the page: **My Apps** (the apps in your personal library) and **App Catalog** (apps that other users have shared). The catalog lets you discover and reuse apps without needing the GitHub URL.
+
+### Browsing the catalog
+
+Open **App Catalog** to see all shared apps. Each listing shows the app name, description, and who shared it. You can:
+
+- **Search** by app name, description, or owner using the search box
+- **Hide installed** apps you already have in your library, using the toggle, so you only see new ones
+
+### Adding an app from the catalog
+
+Open a listing's info dialog and click **Add to my apps**. The app is added to your library just as if you had entered its GitHub URL, and it then appears under **My Apps** where you can launch it.
+
+### Sharing your apps
+
+To share one of your own apps so others can find it in the catalog, open the app's info dialog and click **Share to Catalog**. Shared apps display a **Shared** badge on their card in My Apps.
+
+To stop sharing, click **Unshare** (from the listing's info dialog or your app card). Unsharing removes the catalog listing but leaves the app in your own library. Likewise, removing a shared app from your library does **not** remove its catalog listing — unshare it first if you want to take it down.
+
+Catalog listings point at the owner's repository and branch. Other users always add the app from that source, so they get whatever the repository currently contains when they add or update it.
 
 ## Sharing Apps by URL
 


### PR DESCRIPTION
Brings the Apps documentation in line with current functionality, consolidating the `apps-updates` work with the recent sync pass from `docs/apps-sync-recent-changes`.

## Highlights

**User guide (`workflows/apps-and-jobs`)**
- Rename the Add App "branch" field to **Revision** (tag or branch) and explain that the revision is pinned when an app is added.
- Document the App Catalog: **My Apps / App Catalog / Jobs** tabs, sharing with name/description overrides, adding shared apps, and unsharing.
- Fix the launch form's **Cluster** tab and the **Submit Job** / **Start Service** button labels.
- Add the Job Detail **Overview** tab; clarify what **Update** does under revision pinning.

**Authoring guide**
- Manifest discovery described as the actual two-pass behavior (walk for `runnables.yaml` anywhere; auto-detection only at the repo root, only when none exists).
- Nextflow auto-detection runs `nextflow run repo -ansi-log false` from the work dir.
- Pixi auto-detection exports task env vars as the runnable's default env vars.
- Document the runnable **`working_dir`** field and a dedicated **Working Directory** section in the execution guide.
- Clarify that the requirement check runs after env setup but before `pre_run`/command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)